### PR TITLE
Improve frontend upload error messaging

### DIFF
--- a/frontend/index.jsx
+++ b/frontend/index.jsx
@@ -4,10 +4,45 @@ export default function Home() {
   const [image, setImage] = useState(null);
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const parseErrorResponse = async (res) => {
+    const defaultMessage =
+      res.status === 0
+        ? 'The server could not process your image. Please try again later.'
+        : `The server returned ${res.status}${
+            res.statusText ? ` ${res.statusText}` : ''
+          }. Please try again.`;
+    const contentType = res.headers.get('content-type') || '';
+
+    try {
+      if (contentType.includes('application/json')) {
+        const errorBody = await res.json();
+        return (
+          errorBody?.message ||
+          errorBody?.error ||
+          errorBody?.detail ||
+          defaultMessage
+        );
+      }
+
+      if (contentType.includes('text/')) {
+        const errorText = await res.text();
+        if (errorText.trim()) {
+          return errorText;
+        }
+      }
+    } catch (_parseError) {
+      // Ignore parsing issues and fall back to the default message.
+    }
+
+    return defaultMessage;
+  };
 
   const handleFileChange = (e) => {
     setImage(e.target.files[0]);
     setResult(null);
+    setError(null);
   };
 
   const handleUpload = async () => {
@@ -15,13 +50,39 @@ export default function Home() {
     const formData = new FormData();
     formData.append('file', image);
     setLoading(true);
-    const res = await fetch('http://localhost:5000/api/detect', {
-      method: 'POST',
-      body: formData,
-    });
-    const data = await res.json();
-    setResult(data);
-    setLoading(false);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch('http://localhost:5000/api/detect', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const message = await parseErrorResponse(res);
+        throw new Error(message);
+      }
+
+      const data = await res.json();
+      setResult(data);
+    } catch (err) {
+      setResult(null);
+      if (err instanceof TypeError || err?.message === 'Failed to fetch') {
+        setError(
+          'We could not reach the detection service. Please check your connection and try again.'
+        );
+        return;
+      }
+
+      if (err instanceof Error && err.message) {
+        setError(err.message);
+        return;
+      }
+
+      setError('An unexpected error occurred.');
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -35,6 +96,11 @@ export default function Home() {
       >
         {loading ? 'Processing...' : 'Detect Areas'}
       </button>
+      {error && (
+        <p className="mt-2 text-sm text-red-600" role="alert">
+          {error}
+        </p>
+      )}
       {result && (
         <div className="mt-4 text-left">
           <h2 className="font-semibold">Detection Result:</h2>


### PR DESCRIPTION
## Summary
- add a helper to parse failed responses and surface clearer server feedback
- reset the previous detection result when starting a new request or when an error occurs
- refine network failure handling so the UI reports unreachable services more reliably

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4da40a5cc8332b7b0745ca0e74137